### PR TITLE
fix: 채팅 수정/삭제 시 안 읽은 메시지 수 증가 문제 해결

### DIFF
--- a/src/main/java/com/code808/calmdesk/domain/chatting/controller/ChattingController.java
+++ b/src/main/java/com/code808/calmdesk/domain/chatting/controller/ChattingController.java
@@ -67,7 +67,7 @@ public class ChattingController {
     public ResponseEntity<ChattingDto.ChatMessageRes> editMessage(@PathVariable("messageId") Long messageId,
             @RequestBody ChattingDto.ChatMessageEditReq request,
             Principal principal) {
-        return ResponseEntity.ok(ChattingDto.ChatMessageRes.from(chatService.editMessage(messageId, request, principal.getName())));
+        return ResponseEntity.ok(ChattingDto.ChatMessageRes.from(chatService.editMessage(messageId, request, principal.getName()), ChattingDto.ChatMessageRes.MessageType.EDIT));
     }
 
     /**

--- a/src/main/java/com/code808/calmdesk/domain/chatting/dto/ChattingDto.java
+++ b/src/main/java/com/code808/calmdesk/domain/chatting/dto/ChattingDto.java
@@ -100,8 +100,13 @@ public class ChattingDto {
         private LocalDateTime createdDate;
         private boolean isDeleted;
         private int unreadCount;
+        private MessageType messageType;
 
-        public static ChatMessageRes from(ChatMessage message) {
+        public enum MessageType {
+            TALK, EDIT, DELETE
+        }
+
+        public static ChatMessageRes from(ChatMessage message, MessageType type) {
             return ChatMessageRes.builder()
                     .id(message.getId())
                     .roomId(message.getChatRoom().getRoomId())
@@ -110,11 +115,12 @@ public class ChattingDto {
                     .content(message.isDeleted() ? "삭제된 메시지입니다." : message.getContent())
                     .createdDate(message.getCreatedDate())
                     .isDeleted(message.isDeleted())
-                    .unreadCount(0) // 기본값 0, 서비스에서 별도 계산 필요 시 설정
+                    .unreadCount(0)
+                    .messageType(type)
                     .build();
         }
 
-        public static ChatMessageRes from(ChatMessage message, int unreadCount) {
+        public static ChatMessageRes from(ChatMessage message, int unreadCount, MessageType type) {
             return ChatMessageRes.builder()
                     .id(message.getId())
                     .roomId(message.getChatRoom().getRoomId())
@@ -124,6 +130,7 @@ public class ChattingDto {
                     .createdDate(message.getCreatedDate())
                     .isDeleted(message.isDeleted())
                     .unreadCount(unreadCount)
+                    .messageType(type)
                     .build();
         }
     }

--- a/src/main/java/com/code808/calmdesk/domain/chatting/repository/ChattingMessageRepository.java
+++ b/src/main/java/com/code808/calmdesk/domain/chatting/repository/ChattingMessageRepository.java
@@ -17,5 +17,5 @@ public interface ChattingMessageRepository extends JpaRepository<ChatMessage, Lo
     // 페이지네이션: 가장 최신 메시지를 가져옴
     List<ChatMessage> findByChatRoomIdOrderByCreatedDateDesc(Long chatRoomId, Pageable pageable);
 
-    int countByChatRoomIdAndIdGreaterThan(Long chatRoomId, Long id);
+    int countByChatRoomIdAndIdGreaterThanAndIsDeletedFalse(Long chatRoomId, Long id);
 }

--- a/src/main/java/com/code808/calmdesk/domain/chatting/service/ChattingServiceImpl.java
+++ b/src/main/java/com/code808/calmdesk/domain/chatting/service/ChattingServiceImpl.java
@@ -91,9 +91,9 @@ public class ChattingServiceImpl implements ChattingService {
 
             int unreadCount;
             if (myRoomMember.getLastReadMessageId() != null) {
-                unreadCount = chatMessageRepository.countByChatRoomIdAndIdGreaterThan(room.getId(), myRoomMember.getLastReadMessageId());
+                unreadCount = chatMessageRepository.countByChatRoomIdAndIdGreaterThanAndIsDeletedFalse(room.getId(), myRoomMember.getLastReadMessageId());
             } else {
-                unreadCount = chatMessageRepository.countByChatRoomIdAndIdGreaterThan(room.getId(), 0L);
+                unreadCount = chatMessageRepository.countByChatRoomIdAndIdGreaterThanAndIsDeletedFalse(room.getId(), 0L);
             }
 
             return ChattingDto.ChatRoomRes.from(room, myRoomMember.getRoomNameAlias(), lastMsg,
@@ -129,7 +129,7 @@ public class ChattingServiceImpl implements ChattingService {
 
         int unreadCount = members.size() - 1;
 
-        ChattingDto.ChatMessageRes response = ChattingDto.ChatMessageRes.from(savedMessage, unreadCount);
+        ChattingDto.ChatMessageRes response = ChattingDto.ChatMessageRes.from(savedMessage, unreadCount, ChattingDto.ChatMessageRes.MessageType.TALK);
 
         messagingTemplate.convertAndSend("/sub/chat/room/" + room.getRoomId(), response);
 
@@ -153,7 +153,7 @@ public class ChattingServiceImpl implements ChattingService {
         message.updateContent(request.getContent());
 
         // 소켓 전송 (수정 이벤트)
-        ChattingDto.ChatMessageRes response = ChattingDto.ChatMessageRes.from(message, 0); // 수정 시 읽음 카운트는 갱신 안 함
+        ChattingDto.ChatMessageRes response = ChattingDto.ChatMessageRes.from(message, 0, ChattingDto.ChatMessageRes.MessageType.EDIT); // 수정 시 읽음 카운트는 갱신 안 함
         messagingTemplate.convertAndSend("/sub/chat/room/" + message.getChatRoom().getRoomId(), response);
 
         // 모든 참여자에게 개인 토픽으로도 전송 (목록 업데이트용)
@@ -178,7 +178,7 @@ public class ChattingServiceImpl implements ChattingService {
         message.delete();
 
         // 소켓 전송 (삭제 이벤트)
-        ChattingDto.ChatMessageRes response = ChattingDto.ChatMessageRes.from(message, 0);
+        ChattingDto.ChatMessageRes response = ChattingDto.ChatMessageRes.from(message, 0, ChattingDto.ChatMessageRes.MessageType.DELETE);
         messagingTemplate.convertAndSend("/sub/chat/room/" + message.getChatRoom().getRoomId(), response);
 
         // 모든 참여자에게 개인 토픽으로도 전송 (목록 업데이트용)
@@ -250,13 +250,15 @@ public class ChattingServiceImpl implements ChattingService {
         return messages.stream()
                 .map(msg -> {
                     int unreadCount = 0;
-                    for (ChatRoomMember member : members) {
-                        Long lastReadId = member.getLastReadMessageId();
-                        if (lastReadId == null || lastReadId < msg.getId()) {
-                            unreadCount++;
+                    if (!msg.isDeleted()) {
+                        for (ChatRoomMember member : members) {
+                            Long lastReadId = member.getLastReadMessageId();
+                            if (lastReadId == null || lastReadId < msg.getId()) {
+                                unreadCount++;
+                            }
                         }
                     }
-                    return ChattingDto.ChatMessageRes.from(msg, unreadCount);
+                    return ChattingDto.ChatMessageRes.from(msg, unreadCount, ChattingDto.ChatMessageRes.MessageType.TALK);
                 })
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
## 1. 🔗 관련된 이슈 링크
- Closes #93 

## 2. 작업 종류
- [ ] ✨ 기능 추가 (Feature)
- [x] 🐛 버그 수정 (Bug Fix)
- [ ] ♻️ 리팩토링 (Refactoring)
- [ ] 🔥 불필요한 코드 삭제 (Remove)
- [ ] 📝 문서 수정 (Documentation)
- [ ] ⚙️ 설정 변경 (Configuration)

## 3. 작업 내용
- **채팅 메시지 타입 구분 로직 추가** - Backend/src/main/java/com/code808/calmdesk/domain/chatting/dto/ChattingDto.java
  - ChatMessageRes DTO에 `MessageType` (TALK, EDIT, DELETE) 추가
- **삭제된 메시지 제외 카운트 쿼리 추가** - Backend/src/main/java/com/code808/calmdesk/domain/chatting/repository/ChattingMessageRepository.java
  - countByChatRoomIdAndIdGreaterThanAndIsDeletedFalse 메서드 추가
- **메시지 상태 변경 알림 로직 수정** - Backend/src/main/java/com/code808/calmdesk/domain/chatting/service/ChattingServiceImpl.java
  - 메시지 생성, 수정, 삭제 시 각각의 타입을 명시하여 소켓 전송하도록 수정
  - 안 읽은 메시지 수 계산 시 삭제된 메시지 제외 처리
- **수정 API 응답 타입 지정** - Backend/src/main/java/com/code808/calmdesk/domain/chatting/controller/ChattingController.java
  - 메시지 수정 시 `MessageType.EDIT` 타입을 반환하도록 수정